### PR TITLE
Handle auth and profile loading errors

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -92,8 +92,7 @@ export const AuthProvider = ({ children }) => {
             {
               id: userId,
               full_name: user?.user_metadata?.full_name || '',
-              avatar_url: user?.user_metadata?.avatar_url || '',
-              role: 'admin'
+              avatar_url: user?.user_metadata?.avatar_url || ''
             }
           ])
           .select()

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -5,6 +5,17 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://placeholder.supabase.co'
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBsYWNlaG9sZGVyIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDA5OTUyMDAsImV4cCI6MTk1NjU3MTIwMH0.placeholder'
 
+// Warn if env vars are missing to avoid confusing 403s due to placeholder credentials
+if (
+  typeof window !== 'undefined' &&
+  (supabaseUrl.includes('placeholder') || supabaseAnonKey.endsWith('.placeholder'))
+) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[Supabase] Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY. Using placeholders will cause 403 errors. Configure your .env with valid project credentials.'
+  )
+}
+
 // Criar cliente Supabase
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {


### PR DESCRIPTION
Remove hardcoded 'admin' role on profile creation and add warning for missing Supabase env vars to prevent 403 errors.

The hardcoded 'admin' role could violate RLS policies or column constraints, leading to profile creation failures. The new warning helps diagnose 403 errors that occur when placeholder Supabase credentials are used, which is a common cause of such errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-4607192e-548c-4d1e-b2f8-f41c18171eea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4607192e-548c-4d1e-b2f8-f41c18171eea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

