### PR TITLE
Investigar falha na exibição de receitas e cursos

### DIFF
--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -29,6 +29,7 @@ function Badge({
   className,
   variant,
   asChild = false,
+  children,
   ...props
 }) {
   const Comp = asChild ? Slot : "span"
@@ -37,7 +38,10 @@ function Badge({
     <Comp
       data-slot="badge"
       className={cn(badgeVariants({ variant }), className)}
-      {...props} />
+      {...props}
+    >
+      {children}
+    </Comp>
   );
 }
 

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -40,6 +40,7 @@ function Button({
   variant,
   size,
   asChild = false,
+  children,
   ...props
 }) {
   const Comp = asChild ? Slot : "button"
@@ -48,7 +49,10 @@ function Button({
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
-      {...props} />
+      {...props}
+    >
+      {children}
+    </Comp>
   );
 }
 

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils"
 
 function Card({
   className,
+  children,
   ...props
 }) {
   return (
@@ -13,12 +14,16 @@ function Card({
         "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
         className
       )}
-      {...props} />
+      {...props}
+    >
+      {children}
+    </div>
   );
 }
 
 function CardHeader({
   className,
+  children,
   ...props
 }) {
   return (
@@ -28,36 +33,48 @@ function CardHeader({
         "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
         className
       )}
-      {...props} />
+      {...props}
+    >
+      {children}
+    </div>
   );
 }
 
 function CardTitle({
   className,
+  children,
   ...props
 }) {
   return (
     <div
       data-slot="card-title"
       className={cn("leading-none font-semibold", className)}
-      {...props} />
+      {...props}
+    >
+      {children}
+    </div>
   );
 }
 
 function CardDescription({
   className,
+  children,
   ...props
 }) {
   return (
     <div
       data-slot="card-description"
       className={cn("text-muted-foreground text-sm", className)}
-      {...props} />
+      {...props}
+    >
+      {children}
+    </div>
   );
 }
 
 function CardAction({
   className,
+  children,
   ...props
 }) {
   return (
@@ -67,26 +84,34 @@ function CardAction({
         "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
         className
       )}
-      {...props} />
+      {...props}
+    >
+      {children}
+    </div>
   );
 }
 
 function CardContent({
   className,
+  children,
   ...props
 }) {
-  return (<div data-slot="card-content" className={cn("px-6", className)} {...props} />);
+  return (<div data-slot="card-content" className={cn("px-6", className)} {...props}>{children}</div>);
 }
 
 function CardFooter({
   className,
+  children,
   ...props
 }) {
   return (
     <div
       data-slot="card-footer"
       className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
-      {...props} />
+      {...props}
+    >
+      {children}
+    </div>
   );
 }
 


### PR DESCRIPTION
Fixes UI components (`Card`, `Button`, `Badge`) to render `children`, resolving empty content display on recipe and course pages.

The `Card` (and its sub-components like `CardHeader`, `CardTitle`, etc.), `Button`, and `Badge` components were previously implemented to return self-closing elements, effectively ignoring any `children` passed to them. This resulted in visually empty UI elements on pages that relied on these components (e.g., `/recipes` and `/courses`), even though data was being fetched correctly and no errors appeared in the console. By explicitly accepting and rendering `children`, the content is now correctly displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3d22d3c-bd1e-413e-99da-98f1e425fe04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3d22d3c-bd1e-413e-99da-98f1e425fe04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

